### PR TITLE
Solidity file syntax highlighting.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
Source: https://medium.com/@danielque/psa-how-to-fix-githubs-syntax-highlighting-for-solidity-4e9867c540b6